### PR TITLE
Fix Spotify episode URL mappings

### DIFF
--- a/FIX_SPOTIFY_URLS.md
+++ b/FIX_SPOTIFY_URLS.md
@@ -1,0 +1,71 @@
+# Fix Spotify URL Mappings in Database
+
+## Problem
+The database contains incorrect Spotify URLs for quotes. Many quotes from different episodes are linking to the same wrong episode (likely S02E21). This happened because the episode mapping files were missing during the initial data import.
+
+## Solution
+Regenerate the CSV data with correct Spotify URLs using proper episode mappings, then re-import to the database.
+
+## Steps to Fix
+
+### 1. Generate Spotify Episode Mapping
+Fetch all Spotify episodes and create the mapping file:
+```bash
+python scripts/fetch_spotify_episodes.py
+```
+This creates `spotify_episode_mapping.csv` with episode data from Spotify API.
+
+### 2. Create Episode Mapping JSON
+Map your data files to Spotify episodes:
+```bash
+python scripts/create_mapping.py
+```
+This creates `episode_mapping.json` that maps episode IDs (e.g., `podcast-s1e01`) to Spotify episode IDs.
+
+**Note:** Both scripts require:
+- Spotify API credentials (CLIENT_ID and CLIENT_SECRET) if fetching from API
+- Or existing `spotify_episode_mapping.csv` file if you have one
+
+### 3. Regenerate CSV with Correct URLs
+Convert JSON transcripts to CSV with proper Spotify URLs:
+```bash
+python scripts/json_to_csv.py
+```
+This reads from `data/*.json` files and creates `out/quotes.csv` with correct Spotify URLs using the mapping files.
+
+**Verify:** Check that the CSV contains correct Spotify URLs before proceeding.
+
+### 4. Re-import to Database
+Clear existing data and import the corrected CSV:
+```bash
+python scripts/csv_to_postgres.py
+```
+This script:
+- Deletes all existing quotes from the database
+- Imports quotes from `out/quotes.csv`
+- Skips episodes without Spotify URLs (Best Of episodes)
+- Shows progress during import
+
+### 5. Verify the Fix
+Test a few searches to confirm Spotify links now point to the correct episodes:
+- Search for quotes from "The Future" episode - should link to that episode, not "Law and Order"
+- Check multiple episodes to ensure mappings are correct
+
+## Files Involved
+
+- `scripts/fetch_spotify_episodes.py` - Fetches Spotify episode data
+- `scripts/create_mapping.py` - Creates episode mapping JSON
+- `scripts/json_to_csv.py` - Converts JSON to CSV with Spotify URLs (already fixed to not use hardcoded fallback)
+- `scripts/csv_to_postgres.py` - Imports CSV to PostgreSQL (already improved with batch processing)
+- `spotify_episode_mapping.csv` - Generated mapping file (needs to be created)
+- `episode_mapping.json` - Generated mapping file (needs to be created)
+- `out/quotes.csv` - Generated CSV file (needs to be regenerated)
+
+## Important Notes
+
+- The code in `scripts/json_to_csv.py` has already been fixed to return empty strings instead of wrong episode IDs when mappings aren't found
+- This fix prevents future wrong URLs, but doesn't fix existing database data
+- You MUST regenerate and re-import the data to fix existing incorrect URLs
+- Make sure you have access to the original JSON transcript files in the `data/` directory
+- Back up your database before running `csv_to_postgres.py` if you want to preserve existing data
+

--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,14 @@
 from fastapi import FastAPI, Query, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from dotenv import load_dotenv
+import os
+
+# Load environment variables from .env file
+load_dotenv()
+
 from app.search_core import search_quotes, log_search, get_stats
 from app.database import init_database
-import os
 
 app = FastAPI(title="XFM Quote Finder")
 

--- a/app/search_core.py
+++ b/app/search_core.py
@@ -103,13 +103,13 @@ def log_search(query: str, top_k: int, ip: str, user_agent: str):
 def get_stats():
     """Get database statistics."""
     with get_connection() as conn:
-        result = conn.execute("""
+        result = conn.execute(text("""
             SELECT 
                 COUNT(*) as total_quotes,
                 COUNT(DISTINCT episode_id) as unique_episodes,
                 ARRAY_AGG(DISTINCT episode_id ORDER BY episode_id) as episodes
             FROM quotes
-        """)
+        """))
         row = result.fetchone()
         return {
             "total_quotes": row.total_quotes,

--- a/scripts/csv_to_postgres.py
+++ b/scripts/csv_to_postgres.py
@@ -7,6 +7,11 @@ import csv
 import os
 import sys
 from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
 from app.database import get_connection, init_database
 
 CSV_PATH = Path("out/quotes.csv")

--- a/scripts/delete_all_quotes.py
+++ b/scripts/delete_all_quotes.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Delete all quotes from the database and verify deletion.
+"""
+import os
+import sys
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+def delete_all_quotes():
+    """Delete all quotes and verify."""
+    print("Delete All Quotes from Database")
+    print("="*70)
+    
+    # Check if DATABASE_URL is set
+    if not os.getenv("DATABASE_URL"):
+        print("❌ DATABASE_URL environment variable not set")
+        sys.exit(1)
+    
+    try:
+        from app.database import get_connection
+    except Exception as e:
+        print(f"❌ Error importing database module: {e}")
+        sys.exit(1)
+    
+    # Get current count
+    print("\nChecking current state...")
+    try:
+        with get_connection() as conn:
+            from sqlalchemy import text
+            
+            result = conn.execute(text("SELECT COUNT(*) FROM quotes"))
+            current_count = result.fetchone()[0]
+            print(f"Current quotes in database: {current_count:,}")
+            
+            if current_count == 0:
+                print("\n✅ Database is already empty. Nothing to delete.")
+                return True
+    except Exception as e:
+        print(f"❌ Error checking current state: {e}")
+        sys.exit(1)
+    
+    # Confirm deletion (skip if --yes flag provided)
+    if "--yes" not in sys.argv:
+        print(f"\n⚠️  WARNING: About to delete {current_count:,} quotes from the database")
+        print("This action cannot be undone!")
+        
+        try:
+            response = input("\nType 'DELETE' to confirm: ")
+            if response != "DELETE":
+                print("❌ Deletion cancelled")
+                return False
+        except EOFError:
+            print("\n❌ Interactive input not available. Use --yes flag to skip confirmation.")
+            print("   Example: uv run python3 scripts/delete_all_quotes.py --yes")
+            return False
+    else:
+        print(f"\n⚠️  Deleting {current_count:,} quotes from the database (--yes flag provided)")
+    
+    # Delete all quotes
+    print("\n🗑️  Deleting all quotes...")
+    try:
+        with get_connection() as conn:
+            from sqlalchemy import text
+            
+            result = conn.execute(text("DELETE FROM quotes"))
+            conn.commit()
+            deleted_count = result.rowcount
+            print(f"   Deleted {deleted_count:,} quotes")
+    except Exception as e:
+        print(f"❌ Error deleting quotes: {e}")
+        sys.exit(1)
+    
+    # Verify deletion
+    print("\nVerifying deletion...")
+    try:
+        with get_connection() as conn:
+            from sqlalchemy import text
+            
+            result = conn.execute(text("SELECT COUNT(*) FROM quotes"))
+            remaining_count = result.fetchone()[0]
+            
+            if remaining_count == 0:
+                print(f"✅ Confirmed: Database is now empty ({remaining_count} quotes)")
+                
+                # Also check for any other data
+                result = conn.execute(text("""
+                    SELECT COUNT(DISTINCT episode_id) FROM quotes
+                """))
+                episode_count = result.fetchone()[0]
+                print(f"   Unique episodes: {episode_count}")
+                
+                return True
+            else:
+                print(f"❌ ERROR: Expected 0 quotes, but found {remaining_count:,}")
+                print("   Some quotes were not deleted!")
+                return False
+    except Exception as e:
+        print(f"❌ Error verifying deletion: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    success = delete_all_quotes()
+    sys.exit(0 if success else 1)
+


### PR DESCRIPTION
- Fetched fresh Spotify episode data (149 episodes)
- Fixed guide episode mappings to use actual episode names from JSON files
- Fixed 'Law and Order' -> 'Law & Order' mapping
- Regenerated CSV with correct Spotify URLs (119,207 quotes)
- Verified all 118 episodes have unique Spotify IDs
- Imported corrected data to database
- Added delete_all_quotes.py utility script
- Updated scripts to load .env file for DATABASE_URL